### PR TITLE
Treat a single "." as a valid diploid missing genotype.

### DIFF
--- a/src/SyncedVcfData.cpp
+++ b/src/SyncedVcfData.cpp
@@ -56,6 +56,7 @@ namespace EAGLE {
 	for (int j=0; j<ploidy; j++)
 	  {
 	    if ( ptr[j]==bcf_int32_vector_end ) { // this sample is haploid if ploidy==2
+	      if ( missing ) continue;  // missing diploid genotype can be written in VCF as "."
 	      cerr << "ERROR: ref genotypes contain haploid sample" << endl;
 	      exit(1);
 	    }
@@ -103,6 +104,7 @@ namespace EAGLE {
 	for (int j=0; j<ploidy; j++)
 	  {
 	    if ( ptr[j]==bcf_int32_vector_end ) { // this sample is haploid if ploidy==2
+	      if ( missing ) continue;  // missing diploid genotype can be written in VCF as "."
 	      cerr << "ERROR: target genotypes contain haploid sample" << endl;
 	      exit(1);
 	    }


### PR DESCRIPTION
We've got jobs failing with "ERROR: target genotypes contain haploid sample". Since "." can represent a valid (missing) diploid genotype, this pull request will treat it as such.