### PR TITLE
Fixing Segmentation fault in GenoData::initBed

### DIFF
--- a/src/GenoData.cpp
+++ b/src/GenoData.cpp
@@ -594,7 +594,7 @@ namespace EAGLE {
 	}
 	else {
 	  if (numSnpsFailedQC < 5)
-	    cout << "Filtering snp " << snpsPreQC[mbed].ID << ": "
+	    cout << "Filtering snp " << snpsPreQC[m].ID << ": "
 		 << snpsPreQC[m].miss << " missing" << endl;
 	  numSnpsFailedQC++;
 	}


### PR DESCRIPTION
I believe in GenoData.cpp:597 the Filtering statements accesses snpsPreQC[mbed].ID instead of snpsPreQC[m].ID. This results in a 'Segmentation fault' when the number of snps failing QC occur after the mbed value is higher than what the snpsPreQC array can accommodate. 

The typical case when this error is triggered when you have a bed,bim,fam file with multiple chromosomes (e.g. 1,2,3) and you use the --chrom flag to phase particular chromosomes. If you 191160 SNPs in 1, 200166 SNPs in 2 and 168248 SNPs in 3. Then --chrom=1 will never trigger the segfault since mbed and m are equivalent. --chrom=2 will likely never trigger a segfault since chrom 2 has more SNPs than chrom 1 thus even if mbed > m likely you only access that memory well before you overrun the buffer. --chrom=3 and subsequent chroms will throw the error since mbed > m and guaranteed to be > 168248. 

This error needs to be fixed any ways since likely wrong IDs are being output.